### PR TITLE
The using statement is required otherwise IOutput<T> does not resolve.

### DIFF
--- a/NugetContent/Index.cs.pp
+++ b/NugetContent/Index.cs.pp
@@ -1,3 +1,5 @@
+using Simple.Web.Behaviors;
+
 namespace $rootnamespace$
 {
     using Simple.Web;


### PR DESCRIPTION
Hey Mark,

Just got a blank ASPNET project and used nuget to install-package simple.web - Index.cs didn't compile due to the missing using statement.
