### PR TITLE
Without the Behaviors namespace, IOutput<T> does not resolve.

### DIFF
--- a/NugetContent/Index.cs.pp
+++ b/NugetContent/Index.cs.pp
@@ -1,6 +1,7 @@
 namespace $rootnamespace$
 {
     using Simple.Web;
+    using Simple.Web.Behaviors;
 
     [UriTemplate("/")]
     public class Index : IGet, IOutput<RawHtml>


### PR DESCRIPTION
From the Nuget context package, in Index.cs, the Simple.Web.Behaviors namespace is needed for IOutput<T> to resolve and the build to succeed.
