### PR TITLE
Mock defaults, a setup script, reduced warnings

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 #if (DEBUG)

--- a/Sandbox/Sandbox.csproj
+++ b/Sandbox/Sandbox.csproj
@@ -14,7 +14,7 @@
     <RootNamespace>Sandbox</RootNamespace>
     <AssemblyName>Sandbox</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <UseIISExpress>true</UseIISExpress>
+    <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>
@@ -149,9 +149,9 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>64578</DevelopmentServerPort>
+          <DevelopmentServerPort>80</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:64578/</IISUrl>
+          <IISUrl>http://sandbox.simpleweb.local/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/Simple.Web.Mocks/MockRequest.cs
+++ b/Simple.Web.Mocks/MockRequest.cs
@@ -4,8 +4,6 @@ namespace Simple.Web.Mocks
     using System.Collections.Generic;
     using System.Collections.Specialized;
     using System.IO;
-    using System.Linq;
-    using Helpers;
     using Http;
 
     public class MockRequest : IRequest
@@ -13,6 +11,7 @@ namespace Simple.Web.Mocks
         public MockRequest()
         {
             QueryString = new Dictionary<string, string>();
+			HttpMethod = "GET";
         }
         public Uri Url { get; set; }
 

--- a/Simple.Web.Razor/SimpleRazorBuildProvider.cs
+++ b/Simple.Web.Razor/SimpleRazorBuildProvider.cs
@@ -21,21 +21,19 @@
                                                                            "System", "System.Text", "System.Linq",
                                                                            "System.Collections.Generic", "Simple.Web", "Simple.Web.Razor"
                                                                        };
-        private CodeCompileUnit _generatedCode = null;
-        private RazorEngineHost _host = null;
-        private IList _virtualPathDependencies;
+        private CodeCompileUnit _generatedCode;
+        private RazorEngineHost _host;
+        private readonly IList _virtualPathDependencies;
 
-        internal RazorEngineHost Host
+    	public SimpleRazorBuildProvider()
+    	{
+    		_virtualPathDependencies = null;
+    	}
+
+    	internal RazorEngineHost Host
         {
-            get
-            {
-                if (_host == null)
-                {
-                    _host = CreateHost();
-                }
-                return _host;
-            }
-            set { _host = value; }
+            get { return _host ?? (_host = CreateHost()); }
+    		set { _host = value; }
         }
 
         // Returns the base dependencies and any dependencies added via AddVirtualPathDependencies
@@ -43,15 +41,9 @@
         {
             get
             {
-                if (_virtualPathDependencies != null)
-                {
-                    // Return a readonly wrapper so as to prevent users from modifying the collection directly.
-                    return ArrayList.ReadOnly(_virtualPathDependencies);
-                }
-                else
-                {
-                    return base.VirtualPathDependencies;
-                }
+            	return _virtualPathDependencies != null 
+					? ArrayList.ReadOnly(_virtualPathDependencies) 
+					: base.VirtualPathDependencies;
             }
         }
 
@@ -119,7 +111,7 @@
             if (_generatedCode == null)
             {
                 var engine = new RazorTemplateEngine(Host);
-                GeneratorResults results = null;
+                GeneratorResults results;
                 using (TextReader reader = InternalOpenReader())
                 {
                     results = engine.GenerateCode(reader);//, className: null, rootNamespace: null, sourceFileName: Host.PhysicalPath);

--- a/Simple.Web.Razor/SimpleRazorBuildProvider.cs
+++ b/Simple.Web.Razor/SimpleRazorBuildProvider.cs
@@ -4,16 +4,12 @@
     using System.CodeDom;
     using System.CodeDom.Compiler;
     using System.Collections;
-    using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Globalization;
     using System.IO;
     using System.Linq;
-    using System.Security;
     using System.Web;
     using System.Web.Compilation;
     using System.Web.Razor;
-    using System.Web.Razor.Generator;
     using System.Web.Razor.Parser.SyntaxTree;
     using Engine;
 

--- a/Simple.Web/Behaviors/Implementations/Redirect.cs
+++ b/Simple.Web/Behaviors/Implementations/Redirect.cs
@@ -1,7 +1,7 @@
 ﻿namespace Simple.Web.Behaviors.Implementations
 {
-    using Simple.Web.Behaviors;
-    using Simple.Web.Http;
+    using Behaviors;
+    using Http;
 
     /// <summary>
     /// This type supports the framework directly and should not be used from your code.
@@ -13,7 +13,6 @@
         /// </summary>
         /// <param name="handler">The handler.</param>
         /// <param name="context">The context.</param>
-        /// <param name="status">The <see cref="Status"/> returned by the Handler.</param>
         /// <returns></returns>
         public static bool Impl(IMayRedirect handler, IContext context)
         {

--- a/Simple.Web/CodeGeneration/IScopedHandler.cs
+++ b/Simple.Web/CodeGeneration/IScopedHandler.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Simple.Web.CodeGeneration
 {

--- a/Simple.Web/CodeGeneration/PipelineFunctionFactory.cs
+++ b/Simple.Web/CodeGeneration/PipelineFunctionFactory.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
@@ -38,7 +37,6 @@
         /// <summary>
         /// Generates a compiled method to run a Handler.
         /// </summary>
-        /// <param name="handlerType">The type of the Handler.</param>
         /// <returns>A compiled delegate to run the Handler asynchronously.</returns>
         public Func<IContext, Task> BuildAsyncRunMethod()
         {
@@ -70,7 +68,7 @@
 
             var createHandler = BuildCreateHandlerExpression();
 
-            var lambdaBlock = Expression.Block(new[] { _handler }, new Expression[] { createHandler, call });
+            var lambdaBlock = Expression.Block(new[] { _handler }, new[] { createHandler, call });
 
             var lambda = Expression.Lambda(lambdaBlock, _context);
             return (Func<IContext, Task>) lambda.Compile();

--- a/Simple.Web/CodeGeneration/WriteView.cs
+++ b/Simple.Web/CodeGeneration/WriteView.cs
@@ -1,10 +1,11 @@
+using System;
+
 namespace Simple.Web.CodeGeneration
 {
     using ContentTypeHandling;
     using Http;
-    using Links;
 
-    static class WriteView
+	static class WriteView
     {
         public static void Impl(object handler, IContext context)
         {
@@ -13,6 +14,7 @@ namespace Simple.Web.CodeGeneration
 
         private static void WriteUsingContentTypeHandler(object handler, IContext context)
         {
+			if (context.Request.HttpMethod == null) throw new Exception("No HTTP Method given");
             if (context.Request.HttpMethod.Equals("HEAD")) return;
             IContentTypeHandler contentTypeHandler;
             if (TryGetContentTypeHandler(context, out contentTypeHandler))

--- a/Simple.Web/Simple.Web.csproj
+++ b/Simple.Web/Simple.Web.csproj
@@ -33,10 +33,6 @@
     <DocumentationFile>bin\Release\Simple.Web.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Owin, Version=0.8.0.0, Culture=neutral, PublicKeyToken=f585506a2da1fef4, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Owin.0.8-ctp1\lib\net40\Owin.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />

--- a/Simple.Web/Simple.Web.csproj
+++ b/Simple.Web/Simple.Web.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Simple.Web.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/setup.cmd
+++ b/setup.cmd
@@ -1,0 +1,5 @@
+@echo off
+cd /d "%~dp0"
+powershell.exe -NoProfile -ExecutionPolicy ByPass ".\setup\SetupWebsite.ps1 -url 'sandbox.simpleweb.local' -name 'SimpleWeb.Sandbox' -location '..\Sandbox' "
+
+pause

--- a/setup/SetupWebsite.ps1
+++ b/setup/SetupWebsite.ps1
@@ -1,0 +1,92 @@
+# This script tries to create or update the IIS Site and HOSTS file entry
+param([string]$url = $(throw "Base dns required"), 
+      [string]$name = $(throw "Site name required"),
+	  [string]$location = $(throw "Filesystem location required")
+     )
+
+$base_folder = Split-Path -parent $MyInvocation.MyCommand.Definition # get path to the script
+#echo "using $base_folder as base"
+if ((Test-Path "$base_folder\Output\SetupErrors.txt") -eq $true) {
+	rm "$base_folder\Output\SetupErrors.txt"
+}
+
+#Import-Module WebAdministration ## fails on WOW64, use direct assembly instead.
+[System.Reflection.Assembly]::LoadFrom( "C:\windows\system32\inetsrv\Microsoft.Web.Administration.dll" ) | out-null 
+$iis = new-object Microsoft.Web.Administration.ServerManager
+
+$expected_sites = @{
+    $url = @($name, "$base_folder\$location");
+}
+
+$required_hosts = $expected_sites.Clone()
+
+try {
+    $hosts_file = "C:\Windows\System32\drivers\etc\hosts"
+    $usr = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+    takeown /F "$hosts_file" | out-null
+    $rule=new-object System.Security.AccessControl.FileSystemAccessRule($usr, "Modify", "Allow")
+    $acl=get-acl $hosts_file
+    $acl.SetAccessRule($rule)
+    set-acl $hosts_file $acl | out-null 
+} catch {
+	echo "Could not get access to system HOSTS file" | out-file "$base_folder\Output\SetupErrors.txt"
+    exit 1
+}
+$hosts_entries = (get-content $hosts_file)
+foreach ($hline in $hosts_entries) {
+    if ($hline.startsWith("#")) {continue}
+    try{$required_hosts.Remove([regex]::split($hline, "\s+")[1])} catch {}
+}
+
+try {
+    if ($required_hosts.Count -gt 0) {
+        Add-Content $hosts_file ("`n")
+    }
+    foreach ($hname in $required_hosts.keys) {
+        Add-Content $hosts_file ("127.0.0.1`t`t"+$hname)
+        echo " - " + $hname + " was missing, now added"
+    }
+} catch {
+    exit 1
+}
+try {
+    $path = Resolve-Path "$base_folder\$location"
+    $rule=new-object System.Security.AccessControl.FileSystemAccessRule("IIS_IUSRS","Modify","ContainerInherit,ObjectInherit","None","Allow")
+    $acl=get-acl $path
+    $acl.SetAccessRule($rule)
+    set-acl $path $acl | out-null 
+} catch {
+	echo "Failed to set IIS root folder permissions" | out-file "$base_folder\Output\SetupErrors.txt"
+    exit 1
+}
+
+$sites = $iis.sites
+$all_hosts = $sites | %{$_.Bindings} | %{$_.Host}
+
+# Now, $required_sites contains binding, name and file path for each new website that needs creating...
+$wc = new-object net.WebClient
+if (-not ($all_hosts -contains $url)) {
+    $bind = $url
+    $path = Resolve-Path "$base_folder\$location"
+    echo "binding $url"
+    try {
+		$pool = $iis.applicationpools | ?{$_.name -eq $name}
+		if (! $pool) {
+			$pool = $iis.ApplicationPools.Add($name)
+			$pool.managedRuntimeVersion = "v4.0"
+		}
+		$webSite = $iis.Sites.Add($name, "http", "*:80:$bind", $path);
+		$webSite.Applications[0].ApplicationPoolName = $name;
+		$webSite.ServerAutoStart = $TRUE;
+		$iis.CommitChanges()
+		
+        try {
+            $probe = $wc.downloadData("http://" + $bind) # Ensures users are created
+        } catch {
+            # expect an error of no permission, so no real need to handle it
+        }
+    } catch {
+		echo "Failed to create IIS website and/or app pool" | out-file "$base_folder\Output\SetupErrors.txt"
+        exit 1
+    }
+}


### PR DESCRIPTION
Hi.

In this change, 
- added a default HTTP method to MockRequest -- all tests green now.
- added an IIS setup script
- set Simple.Web project to ignore missing XMLDOC warnings
- removed a few dead XMLDOC param tags
- removed dead OWIN reference in Simple.Web project.

Cheers,
Iain B.
