### PR TITLE
Attempt at easier linux/mono builds

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -1,4 +1,4 @@
-#I @"packages\FAKE.1.64.6\tools"
+#I @"packages/FAKE.1.64.6/tools"
 #r "FakeLib.dll"
 open Fake
 

--- a/fake.sh
+++ b/fake.sh
@@ -3,7 +3,10 @@ TARGET=$1
 
 if [ -z "$TARGET" ]
 	then
-	TARGET="Default"
+	CTARGET="Default"
+else
+	CTARGET=`echo ${TARGET:0:1} | tr "[:lower:]" "[:upper:]"``echo ${TARGET:1} | tr "[:upper:]" "[:lower:]"`
 fi
 
-mono packages/FAKE.1.64.6/tools/FAKE.exe build.fsx target=$TARGET
+echo "Executing command: $CTARGET"
+mono packages/FAKE.1.64.6/tools/FAKE.exe build.fsx target=$CTARGET

--- a/fake.sh
+++ b/fake.sh
@@ -1,2 +1,9 @@
 #!/bin/bash
-mono packages/FAKE.1.64.6/tools/FAKE.exe build.fsx target=Default
+TARGET=$1 
+
+if [ -z "$TARGET" ]
+	then
+	TARGET="Default"
+fi
+
+mono packages/FAKE.1.64.6/tools/FAKE.exe build.fsx target=$TARGET

--- a/fake.sh
+++ b/fake.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mono packages/FAKE.1.64.6/tools/FAKE.exe build.fsx target=Default


### PR DESCRIPTION
Couple of small suggested inclusions;
- Felt it would be easier to include a bash file for building via FAKE on *nix with Mono.
- FAKE on *nix didn't seem to like the backslashes in build.fsx search path, but Windows doesn't mind, so changed to forward-slashes.
