### PR TITLE
Updated SimplestWeb to use VSTooslPath logic for targets resolution.

### DIFF
--- a/SimplestWeb/SimplestWeb.csproj
+++ b/SimplestWeb/SimplestWeb.csproj
@@ -95,8 +95,12 @@
       <Name>Simple.Web</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <ProjectExtensions>
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">


### PR DESCRIPTION
Changed SimplestWeb to use WebApplication.targets based on VSToolsPath logic which is support by the Mono/FAKE build process to support compiling on *nix.

PS. Have sanity-checked this compiles on Mono _and_ Windows (without v9.0/VS2008 installed).
