### PR TITLE
Fixed Mono version checking.

### DIFF
--- a/fake.sh
+++ b/fake.sh
@@ -24,7 +24,7 @@ else
 	export BUILDTARGETS="$BUILDTARGETS"
 fi
 
-if [[ ! "$MONOVERSION" =~ "version "[2-99]"."[1-99][0-99]"." ]]
+if [[ ! "$MONOVERSION" =~ "version "[2-9]"."[1-9][1-9]"." ]]
 	then
 	echo -e "You must have Mono version 2.11+ installed to compile Simple.Web.\nVisit http://www.go-mono.com/mono-downloads/download.html for the latest version."
 	exit 1


### PR DESCRIPTION
Could swear I'd tested this thoroughly, but just found on another machine with Mono 2.10 it wasn't giving the version check warning.
