### PR TITLE
Fixed test directory (trailing slash) & fake.sh build command auto-capitalisation.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -3,7 +3,7 @@
 open Fake
 
 let buildDir = @"./build/"
-let testDir = @"./test"
+let testDir = @"./test/"
 
 let fxReferences = !! @"*/*.csproj"
 let testReferences = !! @"Tests/**/*.csproj"

--- a/fake.sh
+++ b/fake.sh
@@ -13,7 +13,7 @@ if [ -z "$TARGET" ]
 	CTARGET="Default"
 	echo -e "No build action specified, assuming '${CTARGET}'.\nAvailable actions are \"Clean\", \"Build\", \"BuildTest\", or \"Test\".\n"
 else
-	CTARGET=`echo ${TARGET:0:1} | tr "[:lower:]" "[:upper:]"``echo ${TARGET:1} | tr "[:upper:]" "[:lower:]"`
+	CTARGET=`echo ${TARGET:0:1} | tr "[:lower:]" "[:upper:]"``echo ${TARGET:1}`
 fi
 
 if [ ! -d "$BUILDTARGETS" ]


### PR DESCRIPTION
Probably only noticeable on Mono builds but found the lack of trailing slash when specifying the FAKE test meant assemblies not being copied (ref: OutputPath) correctly. Unfortunately there is also a [bug in FAKE](https://github.com/fsharp/FAKE/pull/56) which is also required to fix OutputPath completely on Mono.

NB: There is also a bug in FAKE stopping xunit from running, working on that now.
