### PR TITLE
HandlerRunnerBuildTests use local IMediaType to resolve test fail

### DIFF
--- a/Tests/Simple.Web.CodeGeneration.Tests/HandlerRunnerBuilderTest.cs
+++ b/Tests/Simple.Web.CodeGeneration.Tests/HandlerRunnerBuilderTest.cs
@@ -1,17 +1,20 @@
 ﻿namespace Simple.Web.CodeGeneration.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Text;
+    using System.Threading.Tasks;
     using Behaviors;
+    using Helpers;
     using Http;
-    using JsonFx;
+    using MediaTypeHandling;
     using Mocks;
     using Xunit;
 
     public class HandlerRunnerBuilderTest
     {
-        static readonly JsonFx.JsonMediaTypeHandler _ = new JsonMediaTypeHandler();
+        static readonly IMediaTypeHandler JsonMediaTypeHandler = new TestJsonMediaTypeHandler();
         private static readonly byte[] TestJson = Encoding.UTF8.GetBytes("{\"Called\": true, \"Test\":\"Pass\"}\r\n");
 
         [Fact]
@@ -188,5 +191,23 @@
     {
         public string Test { get; set; }
         public bool Called { get; set; }
+    }
+
+    [MediaTypes(MediaType.Json, "application/*+json")]
+    public class TestJsonMediaTypeHandler : IMediaTypeHandler
+    {
+        public object Read(Stream inputStream, Type inputType)
+        {
+            return new FooModel()
+            {
+                Test = "Pass",
+                Called = true
+            };
+        }
+
+        public Task Write(IContent content, Stream outputStream)
+        {
+            return TaskHelper.Completed();
+        }
     }
 }


### PR DESCRIPTION
Decided the best way to deal with the [failing tests (race-condition?!)](https://github.com/markrendle/Simple.Web/issues/27) of scanning assembly ExportedTypes was to just use a local IMediaTypeHandler. One _could_ say this also enforces the test boundary, and also removes tests dependency on external library.
## Fixes

```
Simple.Web.CodeGeneration.Tests.HandlerRunnerBuilderTest.CallsPatchWithParameter [FAIL]
   Simple.Web.UnsupportedMediaTypeException : Requested type(s) not available
   Stack Trace:
      c:\Source\GitHub\Simple.Web\Simple.Web\Behaviors\Implementations\SetInput.cs(45,0): at Simple.Web.Behaviors.Implementations.GetInput.Impl[T](IContext context)
      at lambda_method(Closure , Object , IContext )
      c:\Source\GitHub\Simple.Web\Tests\Simple.Web.CodeGeneration.Tests\HandlerRunnerBuilderTest.cs(75,0): at Simple.Web.CodeGeneration.Tests.HandlerRunnerBuilderTest.CallsPatchWithParameter()
```
