### PR TITLE
Mono compatibility: JsonFx & FAKE build specification

### DIFF
--- a/Simple.Web.JsonFx/JsonMediaTypeHandler.cs
+++ b/Simple.Web.JsonFx/JsonMediaTypeHandler.cs
@@ -10,6 +10,7 @@ namespace Simple.Web.JsonFx
     using Helpers;
     using Links;
     using MediaTypeHandling;
+    using global::JsonFx.Model.Filters;
     using global::JsonFx.Json;
     using global::JsonFx.Json.Resolvers;
     using global::JsonFx.Serialization;
@@ -53,7 +54,7 @@ namespace Simple.Web.JsonFx
                 var enumerable = content.Model as IEnumerable<object>;
                 if (enumerable != null)
                 {
-                    output = ProcessList(enumerable);
+                    output = ProcessList(enumerable.ToList());
                 }
                 else
                 {
@@ -62,7 +63,10 @@ namespace Simple.Web.JsonFx
                 byte[] buffer;
                 using (var writer = new StringWriter())
                 {
-                    new JsonWriter().Write(output, writer);
+                    var dataWriterSettings = new DataWriterSettings(new MonoCompatResolverStrategy(),
+                                                                    new Iso8601DateFilter());
+
+                    new JsonWriter(dataWriterSettings).Write(output, writer);
                     buffer = Encoding.Default.GetBytes(writer.ToString());
                 }
                 return outputStream.WriteAsync(buffer, 0, buffer.Length);
@@ -102,7 +106,7 @@ namespace Simple.Web.JsonFx
                         yield return dictionary;
                         continue;
                     }
-                    
+
                 }
 
                 yield return o;

--- a/Simple.Web.JsonFx/MonoCompatResolverStrategy.cs
+++ b/Simple.Web.JsonFx/MonoCompatResolverStrategy.cs
@@ -1,0 +1,13 @@
+using System.Reflection;
+using JsonFx.Serialization.Resolvers;
+
+namespace Simple.Web.JsonFx
+{
+    public class MonoCompatResolverStrategy : PocoResolverStrategy
+    {
+        public override bool IsPropertyIgnored(PropertyInfo member, bool isImmutableType)
+        {
+            return base.IsPropertyIgnored(member, isImmutableType) || member.GetIndexParameters().Length > 0;
+        }
+    }
+}

--- a/Simple.Web.JsonFx/Simple.Web.JsonFx.csproj
+++ b/Simple.Web.JsonFx/Simple.Web.JsonFx.csproj
@@ -47,6 +47,7 @@
       <Link>CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="JsonMediaTypeHandler.cs" />
+    <Compile Include="MonoCompatResolverStrategy.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Simple.Web.JsonFx.Tests/MonoCompatResolverStrategyTests.cs
+++ b/Tests/Simple.Web.JsonFx.Tests/MonoCompatResolverStrategyTests.cs
@@ -1,0 +1,44 @@
+﻿namespace Simple.Web.JsonFx.Tests
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using Links;
+    using MediaTypeHandling;
+    using TestHelpers;
+    using Xunit;
+
+    public class MonoCompatResolverStrategyTests
+    {
+        [Fact]
+        public void SerializingListToJsonHasExpectedData()
+        {
+            const string expectedString = "{\"Customers\":[{\"Id\":42}]}";
+
+            var content = new Content(new CustomersListHandler(), new CustomerList() { Customers = new List<Customer>() { new Customer {Id = 42}}});
+            var target = new JsonMediaTypeHandler();
+            string actual;
+            using (var stream = new NonClosingMemoryStream(new MemoryStream()))
+            {
+                target.Write(content, stream).Wait();
+                stream.Position = 0;
+                using (var reader = new StreamReader(stream))
+                {
+                    actual = reader.ReadToEnd();
+                }
+                stream.ForceDispose();
+            }
+            Assert.NotNull(actual);      
+            Assert.Equal(expectedString, actual);
+        }
+
+        [LinksFrom(typeof(IEnumerable<CustomerList>), "/allcustomers", Rel = "self", Type = "application/vnd.list.customer")]
+        public class CustomersListHandler
+        {
+        }
+
+        public class CustomerList
+        {
+            public IList<Customer> Customers { get; set; }
+        }
+    }
+}

--- a/Tests/Simple.Web.JsonFx.Tests/Simple.Web.JsonFx.Tests.csproj
+++ b/Tests/Simple.Web.JsonFx.Tests/Simple.Web.JsonFx.Tests.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="JsonFxContentTypeHandlerTests.cs" />
+    <Compile Include="MonoCompatResolverStrategyTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This update includes:-
- **Implements a custom JsonFx `ResolverStrategy` for JsonFx (writes only)**
   Side-steps an issue between JsonFx IL Emit and the (stricter than .NET it seems) Mono compiler. Miguel has confirmed this isn't a bug with Mono Runtime JIT and Stephen made clear if someone can fix the OpCodes for IndexProperties he'll take a pull-request, but I drew a blank. Added test to ensure Lists are still parsed correctly.
- **FAKE (fsx) specification changes to compile both `Build + Test` (Mono only)**
   Seems xbuild isn't quite as clever as MSBuild when it comes to copying local dependencies when compiling a Test assembly dependencies. As such I've worked some F# magic/evil/crudeness so that Mono builds run the standard build first so the DLL (e.g. JsonFx.dll) is present in the Test directory when xunit executes.

I believe once the [outstanding ninject issue](https://github.com/markrendle/Simple.Web/issues/31) is fixed we'll have a Mono compiling and test-passing build. _Harrah!_
