### PR TITLE
Performance fix by caching run methods

### DIFF
--- a/src/Simple.Web/Application.cs
+++ b/src/Simple.Web/Application.cs
@@ -93,7 +93,7 @@
                 handlerInfo.Variables.Add(key, context.Request.QueryString[key]);
             }
 
-            var task = PipelineFunctionFactory.Get(handlerInfo)(context);
+            var task = PipelineFunctionFactory.Get(handlerInfo.HandlerType, handlerInfo.HttpMethod)(context, handlerInfo);
             return task ?? MakeCompletedTask();
         }
 


### PR DESCRIPTION
I've run performance tests using WeigHTTP against a simple REST endpoint, like this one:

``` csharp
[UriTemplate("/objects/{Id}")]
public class GetObjectById : IGet, IOutput<GetObjectResponseDto>
{
    public Status Get()
    {
        Output = new GetObjectResponseDto
            {
                Id = Id
            };

        return Status.OK;
    }

    public int Id { get; set; }
    public GetObjectResponseDto Output { get; private set; }
}
```

I noticed that on my machine I could only get a throughput of around **600 req/sec** using IIS 8.0, and the follwing WeigHTTP parameters: 

``` shell
weighttp -n 10000 -c 10 -t 4 -k -H "Accept: application/json" http://localhost/objects/1
```

Compare this to MVC4 doing around 4500 req/sec and Web API around 5500 req/sec.

Using ANTS Profiler I've pinpointed the problem being that the handler run methods are compiled at each requests. Much of this was because the HandlerInfo variables were unique per request.

So, I've made a change so that HandlerInfo is a parameter to the lambda allowing the lambda to be cached under the handler type and HTTP method. 

This has increased the throughput to around **4500 req/sec**.
