### PR TITLE
Updated transforms as not to duplicate compilation tag.

### DIFF
--- a/src/Simple.Web.AspNet/web.config.transform
+++ b/src/Simple.Web.AspNet/web.config.transform
@@ -1,6 +1,6 @@
 <configuration>
   <system.web>
-    <compilation debug="true" targetFramework="4.0">
+    <compilation debug="true">
     </compilation>
     <!-- Uncomment this for running in VS2010 Dev Server -->
     <!--<httpHandlers>

--- a/src/Simple.Web.Razor/web.config.transform
+++ b/src/Simple.Web.Razor/web.config.transform
@@ -4,7 +4,7 @@
     <add key="webPages:Enabled" value="false" />
   </appSettings>
   <system.web>
-    <compilation debug="true" targetFramework="4.0">
+    <compilation debug="true">
       <assemblies>
         <add assembly="System.Web.Abstractions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
         <add assembly="System.Web.Routing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>


### PR DESCRIPTION
Using NuGet to start a new Simple.Web project (even with Razor) is now pretty friction free, however kept finding the compilation tag duplicated in VS2012 due to .NET 4.5.   Have removed the target framework from the compilation tag to stop this, I think the risk is negligible.
#### For example (Razor)
- New `ASP.NET Empty Web Application` called `SimpleWebTest`
- Manage NuGet Package Dependencies / Package-Manager Console
- Install `Simple.Web.AspNet` --> Brings in `Simple.Web`
- Install `Simple.Web.Razor`
- Create class `/IndexModel.cs`
- Add `public string Something { get; set; }`
- Create class `/Index.cs`
- Decorate class with `[UriTemplate("/")]`
- Inherit and implement `IGET` and `IOutput<IndexModel>`
- `return 200;` in `Get()`
- `get { return new IndexModel { Something = "Test" }; }` in `public IndexModel Output`
- Create "Views" folder **(add to nuspec?)**
- Create `/Views/Index.cshtml`
- Add;
  
  <pre>
  @model SimpleWebTest.IndexModel
  
  &lt;html&gt;
      &lt;body&gt;
          Hello!
      &lt;/body&gt;
  &lt;/html&gt;
  </pre>
- Hit F5 to run
