### PR TITLE
HTTP Method properly checked in run method cache

### DIFF
--- a/src/Simple.Web/CodeGeneration/PipelineFunctionFactory.cs
+++ b/src/Simple.Web/CodeGeneration/PipelineFunctionFactory.cs
@@ -25,7 +25,7 @@ namespace Simple.Web.CodeGeneration
 
         public static Func<IContext, HandlerInfo, Task> Get(Type handlerType, string httpMethod)
         {
-            if (!RunMethodCache.ContainsKey(handlerType))
+            if (!RunMethodCache.ContainsKey(handlerType) || !RunMethodCache[handlerType].ContainsKey(httpMethod))
             {
                 lock (RunMethodCache)
                 {


### PR DESCRIPTION
This fixes a bug in the run method cache where the HTTP method was ignored.

``` csharp
if (!RunMethodCache.ContainsKey(handlerType) || !RunMethodCache[handlerType].ContainsKey(httpMethod))
```
