### PR TITLE
Media Type resolution failing for wildcard matches in MediaTypeHandlerEx.GetContentType

### DIFF
--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -1,15 +1,16 @@
 using System.Runtime.CompilerServices;
 using System.Reflection;
 using System.Runtime.InteropServices;
-[assembly: AssemblyCompany("Mark Rendle")]
+[assembly: AssemblyCompany("Mark Rendle, Ian Battersby, and contributors")]
 [assembly: AssemblyProduct("Simple.Web")]
 [assembly: AssemblyCopyright("Copyright (C) Mark Rendle 2012")]
+[assembly: AssemblyTrademark("7c9e14b1afb8068ac85e01b3b9253a12844cd130")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyVersion("0.8.0.51335")]
+[assembly: AssemblyFileVersion("0.8.0.51335")]
 
-[assembly: AssemblyConfiguration("Release")]
-[assembly: AssemblyInformationalVersion("0.0.0.0")]
+[assembly: AssemblyConfiguration("debug")]
+[assembly: AssemblyInformationalVersion("0.8.0.51335")]
 
 [assembly: InternalsVisibleTo("Simple.Web.Autofac.Tests")]
 [assembly: InternalsVisibleTo("Simple.Web.CodeGeneration.Tests")]

--- a/src/Simple.Web.Tests/ApplicationTests/ContentTypeTests.cs
+++ b/src/Simple.Web.Tests/ApplicationTests/ContentTypeTests.cs
@@ -2,89 +2,89 @@
 
 namespace Simple.Web.Tests.ApplicationTests
 {
-	public class ContentTypeTests
-	{
-		[Fact]
-		public void FileWithASingleAcceptTypeReturnsThatType()
-		{
-			var type = Application.GetContentType("any", new[]{"test/type"});
-			
-			Assert.Equal("test/type", type);
-		}
-		
-		[Fact]
-		public void FileWithMultipleAcceptTypeReturnsFirstType()
-		{
-			var type = Application.GetContentType("any", new[]{"type/one", "type/two", "*/*"});
-			
-			Assert.Equal("type/one", type);
-		}
+    public class ContentTypeTests
+    {
+        [Fact]
+        public void FileWithASingleAcceptTypeReturnsThatType()
+        {
+            var type = Application.GetContentType("any", new[] { "test/type" });
 
-		[Fact]
-		public void FileWithNullAcceptTypesReturnsPlainText()
-		{
-			var type = Application.GetContentType("any", null);
-			
-			Assert.Equal("text/plain", type);
-		}
+            Assert.Equal("test/type", type);
+        }
 
-		[Fact]
-		public void FileWithEmptyAcceptTypesReturnsPlainText()
-		{
-			var type = Application.GetContentType("any", new string[]{});
-			
-			Assert.Equal("text/plain", type);
-		}
+        [Fact]
+        public void FileWithMultipleAcceptTypeReturnsFirstType()
+        {
+            var type = Application.GetContentType("any", new[] { "type/one", "type/two", "*/*" });
 
-		[Fact]
-		public void FileWithWildcardAcceptTypeAndNoKnownExtensionReturnsPlainText()
-		{
-			var type = Application.GetContentType("any", new[]{"*/*"});
-			
-			Assert.Equal("text/plain", type);
-		}
+            Assert.Equal("type/one", type);
+        }
 
-		[Fact]
-		public void FileWithWildcardAcceptType_Jpg_ExtensionReturns_Jpeg()
-		{
-			var type = Application.GetContentType("any.jpg", new[]{"*/*"});
-			
-			Assert.Equal("image/jpeg", type);
-		}
-		[Fact]
-		public void FileWithWildcardAcceptType_Jpeg_ExtensionReturns_Jpeg()
-		{
-			var type = Application.GetContentType("any.jpeg", new[]{"*/*"});
-			
-			Assert.Equal("image/jpeg", type);
-		}
-		[Fact]
-		public void FileWithWildcardAcceptType_Png_ExtensionReturns_Png()
-		{
-			var type = Application.GetContentType("any.png", new[]{"*/*"});
-			
-			Assert.Equal("image/png", type);
-		}
-		[Fact]
-		public void FileWithWildcardAcceptType_Gif_ExtensionReturns_gif()
-		{
-			var type = Application.GetContentType("any.gif", new[]{"*/*"});
-			
-			Assert.Equal("image/gif", type);
-		}
-		[Fact]
-		public void FileWithWildcardAcceptType_Js_ExtensionReturns_JavaScript()
-		{
-			var type = Application.GetContentType("any.js", new[]{"*/*"});
-			
-			Assert.Equal("text/javascript", type);
-		}
-		[Fact]
-		public void FileWithWildcardAcceptType_Javascript_ExtensionReturns_JavaScript()
-		{
-			var type = Application.GetContentType("any.JavaScript", new[]{"*/*"});
-			
-			Assert.Equal("text/javascript", type);
-		}
-	}
+        [Fact]
+        public void FileWithNullAcceptTypesReturnsPlainText()
+        {
+            var type = Application.GetContentType("any", null);
+
+            Assert.Equal("text/plain", type);
+        }
+
+        [Fact]
+        public void FileWithEmptyAcceptTypesReturnsPlainText()
+        {
+            var type = Application.GetContentType("any", new string[] { });
+
+            Assert.Equal("text/plain", type);
+        }
+
+        [Fact]
+        public void FileWithWildcardAcceptTypeAndNoKnownExtensionReturnsPlainText()
+        {
+            var type = Application.GetContentType("any", new[] { "*/*" });
+
+            Assert.Equal("text/plain", type);
+        }
+
+        [Fact]
+        public void FileWithWildcardAcceptType_Jpg_ExtensionReturns_Jpeg()
+        {
+            var type = Application.GetContentType("any.jpg", new[] { "*/*" });
+
+            Assert.Equal("image/jpeg", type);
+        }
+        [Fact]
+        public void FileWithWildcardAcceptType_Jpeg_ExtensionReturns_Jpeg()
+        {
+            var type = Application.GetContentType("any.jpeg", new[] { "*/*" });
+
+            Assert.Equal("image/jpeg", type);
+        }
+        [Fact]
+        public void FileWithWildcardAcceptType_Png_ExtensionReturns_Png()
+        {
+            var type = Application.GetContentType("any.png", new[] { "*/*" });
+
+            Assert.Equal("image/png", type);
+        }
+        [Fact]
+        public void FileWithWildcardAcceptType_Gif_ExtensionReturns_gif()
+        {
+            var type = Application.GetContentType("any.gif", new[] { "*/*" });
+
+            Assert.Equal("image/gif", type);
+        }
+        [Fact]
+        public void FileWithWildcardAcceptType_Js_ExtensionReturns_JavaScript()
+        {
+            var type = Application.GetContentType("any.js", new[] { "*/*" });
+
+            Assert.Equal("text/javascript", type);
+        }
+        [Fact]
+        public void FileWithWildcardAcceptType_Javascript_ExtensionReturns_JavaScript()
+        {
+            var type = Application.GetContentType("any.JavaScript", new[] { "*/*" });
+
+            Assert.Equal("text/javascript", type);
+        }
+    }
 }

--- a/src/Simple.Web.Tests/GetHandlerTests.cs
+++ b/src/Simple.Web.Tests/GetHandlerTests.cs
@@ -8,6 +8,9 @@
     using Behaviors;
     using MediaTypeHandling;
     using Mocks;
+
+    using Simple.Web.MediaTypeHandling;
+
     using Xunit;
 
     public class GetHandlerTests
@@ -18,7 +21,7 @@
         }
     }
 
-    
+
 
     [UriTemplate("/")]
     [RespondsWith(MediaType.Html)]

--- a/src/Simple.Web.Tests/MediaTypeHandling/MediaTypeHandlerExTests.cs
+++ b/src/Simple.Web.Tests/MediaTypeHandling/MediaTypeHandlerExTests.cs
@@ -1,0 +1,83 @@
+﻿namespace Simple.Web.Tests.MediaTypeHandling
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading.Tasks;
+
+    using Simple.Web.MediaTypeHandling;
+
+    using Xunit;
+
+    public class MediaTypeHandlerExTests
+    {
+        [Fact]
+        public void GetContentTypeForHandlersWithMatchingWildcardReturnCorrectContentType()
+        {
+            var handler = new GenericJSONHandler();
+            var acceptedTypes = new List<string> { "application/something+json", "text/html" };
+            var contentType = handler.GetContentType(acceptedTypes);
+            Assert.Equal("application/something+json", contentType);
+        }
+
+        [Fact]
+        public void GetContentTypeForHandlersWithNonMatchingWildcardReturnCorrectContentType()
+        {
+            var handler = new GenericJSONWithFallbackHandler();
+            var acceptedTypes = new List<string> { "application/something+xml", "text/html" };
+            var contentType = handler.GetContentType(acceptedTypes);
+            Assert.Equal("text/html", contentType);
+        }
+
+        [Fact]
+        public void GetContentTypeForHandlersMatchExplicitlyReturnCorrectContentType()
+        {
+            var handler = new PlainHTMLHandler();
+            var acceptedTypes = new List<string> { "application/something+json", "text/html" };
+            var contentType = handler.GetContentType(acceptedTypes);
+            Assert.Equal("text/html", contentType);
+        }
+
+        [MediaTypes("application/*+json")]
+        private class GenericJSONHandler : IMediaTypeHandler
+        {
+            public object Read(Stream inputStream, Type inputType)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task Write(IContent content, Stream outputStream)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [MediaTypes("application/*+json", "text/html")]
+        private class GenericJSONWithFallbackHandler : IMediaTypeHandler
+        {
+            public object Read(Stream inputStream, Type inputType)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task Write(IContent content, Stream outputStream)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [MediaTypes("text/html")]
+        private class PlainHTMLHandler : IMediaTypeHandler
+        {
+            public object Read(Stream inputStream, Type inputType)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task Write(IContent content, Stream outputStream)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Simple.Web.Tests/Simple.Web.Tests.csproj
+++ b/src/Simple.Web.Tests/Simple.Web.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="MediaTypeHandling\MediaTypeHandlerExTests.cs" />
     <Compile Include="PublicFolderTests.cs" />
     <Compile Include="UriFromTypeTests.cs" />
     <Compile Include="UriTemplateAttributeTests.cs" />

--- a/src/Simple.Web/MediaTypeHandling/MediaTypeHandlerEx.cs
+++ b/src/Simple.Web/MediaTypeHandling/MediaTypeHandlerEx.cs
@@ -7,7 +7,7 @@ namespace Simple.Web.MediaTypeHandling
 
     static class MediaTypeHandlerEx
     {
-        private static readonly IDictionary<Type, HashSet<string>> Cache = new Dictionary<Type, HashSet<string>>(); 
+        private static readonly IDictionary<Type, HashSet<string>> Cache = new Dictionary<Type, HashSet<string>>();
         private static readonly object Sync = new object();
 
         /// <summary>
@@ -33,7 +33,40 @@ namespace Simple.Web.MediaTypeHandling
                     }
                 }
             }
-            return acceptedTypes.FirstOrDefault(contentTypes.Contains);
+            return acceptedTypes.FirstOrDefault(x => ContainsMatchingContentType(contentTypes, x));
+        }
+
+        private static bool ContainsMatchingContentType(IEnumerable<string> supportedMediaTypes, string mediaType)
+        {
+            bool matched = false;
+            foreach (var supportedMediaType in supportedMediaTypes)
+            {
+                if (IsWildCardMediaType(supportedMediaType))
+                {
+                    matched = MatchesWildCard(supportedMediaType, mediaType);
+                }
+                else
+                {
+                    matched = (supportedMediaType == mediaType);
+                }
+
+                if (matched)
+                {
+                    break;
+                }
+            }
+            return matched;
+        }
+
+        private static bool IsWildCardMediaType(string mediaType)
+        {
+            return mediaType.Contains("*");
+        }
+
+        private static bool MatchesWildCard(string wildcard, string mediaType)
+        {
+            var parts = wildcard.Split('*');
+            return (mediaType.StartsWith(parts[0]) && mediaType.EndsWith(parts[1]));
         }
     }
 }


### PR DESCRIPTION
In our handlers, we have a LinksFrom attribute on the handlers which specifies the media type of the entity.

When making our GET requests, we wish to specify this media type in our Accept header.  However, this fails - because the response Content-Type is never set and an exception is thrown.

The JSONFX handler (which is the one we are using) has a wild card media type listed in it's MediaTypes attribute, and this should match the value passed in the Accept header - but at the moment it does an equality comparison.

So this change was to handle wild card headers and check whether they match the specified media type.
