### PR TITLE
Support multiple query string values with the same key

### DIFF
--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -1,5 +1,5 @@
-using System.Runtime.CompilerServices;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Mark Rendle")]
 [assembly: AssemblyProduct("Simple.Web")]

--- a/src/Sandbox/GetEnumerable.cs
+++ b/src/Sandbox/GetEnumerable.cs
@@ -1,0 +1,27 @@
+﻿namespace Sandbox
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using Simple.Web;
+    using Simple.Web.Behaviors;
+
+    [UriTemplate("/enumerable")]
+    public class GetEnumerable : IGet, IOutput<EnumerableModel>
+    {
+        public Status Get()
+        {
+            this.Output = new EnumerableModel { Messages = this.Message.ToArray() };
+            return 200;
+        }
+
+        public IEnumerable<string> Message { get; set; }
+
+        public EnumerableModel Output { get; set; }
+    }
+
+    public class EnumerableModel
+    {
+        public string[] Messages { get; set; }
+    }
+}

--- a/src/Sandbox/Sandbox.csproj
+++ b/src/Sandbox/Sandbox.csproj
@@ -99,6 +99,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ExceptionHandler.cs" />
+    <Compile Include="GetEnumerable.cs" />
     <Compile Include="GetError.cs" />
     <Compile Include="GetModel.cs" />
     <Compile Include="Models\Form.cs" />
@@ -159,6 +160,9 @@
     <Content Include="Views\Model.cshtml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\EnumerableQSArg.cshtml" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/Sandbox/Views/EnumerableQSArg.cshtml
+++ b/src/Sandbox/Views/EnumerableQSArg.cshtml
@@ -1,0 +1,17 @@
+﻿@model Sandbox.EnumerableModel
+
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <title>title</title>
+    </head>
+    <body>
+        <div>
+              @foreach (var message in Model.Messages)
+              {
+                  <br/>@message
+              }
+        </div>
+    </body>
+</html>

--- a/src/Simple.Web.Autofac.Tests/HandlerFactoryBuilderTests.cs
+++ b/src/Simple.Web.Autofac.Tests/HandlerFactoryBuilderTests.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using Autofac;
+using System;
 using System.Collections.Generic;
-using Autofac;
 
 namespace Simple.Web.Autofac.Tests
 {
-    using System.Reflection;
     using CodeGeneration;
+    using System.Reflection;
     using Xunit;
 
     public class HandlerFactoryBuilderTests

--- a/src/Simple.Web.Autofac.Tests/HandlersModuleTests.cs
+++ b/src/Simple.Web.Autofac.Tests/HandlersModuleTests.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection;
-using Autofac;
+﻿using Autofac;
+using System.Reflection;
 using Xunit;
 
 namespace Simple.Web.Autofac.Tests

--- a/src/Simple.Web.Tests/HandlerBuilderFactoryTests.cs
+++ b/src/Simple.Web.Tests/HandlerBuilderFactoryTests.cs
@@ -11,7 +11,7 @@
         public void CreatesTypeWithParameterlessConstructorUsingDefaultContainer()
         {
             var target = new HandlerBuilderFactory(new Configuration());
-            var actualFunc = target.BuildHandlerBuilder(typeof (ParameterlessConstructorType));
+            var actualFunc = target.BuildHandlerBuilder(typeof(ParameterlessConstructorType));
             var actual = actualFunc(new Dictionary<string, string>());
             Assert.IsType<ParameterlessConstructorType>(actual.Handler);
         }
@@ -20,7 +20,7 @@
         public void CreatingTypeWithNoParameterlessConstructorUsingDefaultContainerThrowsInvalidOperationException()
         {
             var target = new HandlerBuilderFactory(new Configuration());
-            var actualFunc = target.BuildHandlerBuilder(typeof (NoParameterlessConstructorType));
+            var actualFunc = target.BuildHandlerBuilder(typeof(NoParameterlessConstructorType));
             Assert.Throws<InvalidOperationException>(() => actualFunc(new Dictionary<string, string>()));
         }
 
@@ -29,9 +29,60 @@
         {
             var guid = new Guid("FA37E0B4-2DB9-4471-BC6C-229748F417CA");
             var target = new HandlerBuilderFactory(new Configuration());
-            var actualFunc = target.BuildHandlerBuilder(typeof (GuidHolder));
-            var actual = (GuidHolder)actualFunc(new Dictionary<string, string>{{"Guid",guid.ToString()}}).Handler;
+            var actualFunc = target.BuildHandlerBuilder(typeof(GuidHolder));
+            var actual = (GuidHolder)actualFunc(new Dictionary<string, string> { { "Guid", guid.ToString() } }).Handler;
             Assert.Equal(guid, actual.Guid);
+        }
+
+        [Fact]
+        public void SetsEnumerableGuidPropertyCorrectly()
+        {
+            var guidCollection = new[]
+                                     {
+                                         new Guid("FA37E0B4-2DB9-4471-BC6C-229748F417CA"),
+                                         new Guid("47A210D9-7E5D-480A-9300-B2CF1443C496")
+                                     };
+            var target = new HandlerBuilderFactory(new Configuration());
+            var actualFunc = target.BuildHandlerBuilder(typeof(EnumerableGuidHolder));
+            var actual = (EnumerableGuidHolder)actualFunc(new Dictionary<string, string> { { "Guids", "FA37E0B4-2DB9-4471-BC6C-229748F417CA\t47A210D9-7E5D-480A-9300-B2CF1443C496" } }).Handler;
+            Assert.Equal(guidCollection, actual.Guids);
+        }
+
+        [Fact]
+        public void SetsEnumerableStringPropertyCorrectly()
+        {
+            var stringCollection = new[]
+                                     {
+                                         "hello",
+                                         "world"
+                                     };
+            var target = new HandlerBuilderFactory(new Configuration());
+            var actualFunc = target.BuildHandlerBuilder(typeof(EnumerableStringHolder));
+            var actual = (EnumerableStringHolder)actualFunc(new Dictionary<string, string> { { "Strings", "hello\tworld" } }).Handler;
+            Assert.Equal((IEnumerable<string>)stringCollection, (IEnumerable<string>)actual.Strings);
+        }
+
+        [Fact]
+        public void SetsEnumerableEnumPropertyCorrectly()
+        {
+            var enumCollection = new[]
+                                     {
+                                         Enterprise.Kirk,
+                                         Enterprise.Spock
+                                     };
+            var target = new HandlerBuilderFactory(new Configuration());
+            var actualFunc = target.BuildHandlerBuilder(typeof(EnumerableEnumHolder));
+            var actual = (EnumerableEnumHolder)actualFunc(new Dictionary<string, string> { { "Trekkers", "Kirk\tSpock" } }).Handler;
+            Assert.Equal((IEnumerable<Enterprise>)enumCollection, (IEnumerable<Enterprise>)actual.Trekkers);
+        }
+
+        [Fact]
+        public void SetsSingleEnumPropertyCorrectly()
+        {
+            var target = new HandlerBuilderFactory(new Configuration());
+            var actualFunc = target.BuildHandlerBuilder(typeof(SingleEnumHolder));
+            var actual = (SingleEnumHolder)actualFunc(new Dictionary<string, string> { { "Trekker", "Uhura" } }).Handler;
+            Assert.Equal(Enterprise.Uhura, actual.Trekker);
         }
     }
 
@@ -39,15 +90,48 @@
     {
         public NoParameterlessConstructorType(int n)
         {
-            
+
         }
     }
+
     class ParameterlessConstructorType
     {
-        
+
     }
+
     class GuidHolder
     {
         public Guid? Guid { get; set; }
+    }
+
+    class EnumerableGuidHolder
+    {
+        public IEnumerable<Guid> Guids { get; set; }
+    }
+
+    class EnumerableStringHolder
+    {
+        public IEnumerable<string> Strings { get; set; }
+    }
+
+    enum Enterprise
+    {
+        Kirk,
+        McCoy,
+        Scott,
+        Spock,
+        Uhura,
+        Chekov,
+        Zulu
+    }
+
+    class EnumerableEnumHolder
+    {
+        public IEnumerable<Enterprise> Trekkers { get; set; }
+    }
+
+    class SingleEnumHolder
+    {
+        public Enterprise Trekker { get; set; }
     }
 }

--- a/src/Simple.Web/Priority.cs
+++ b/src/Simple.Web/Priority.cs
@@ -12,26 +12,26 @@
         /// <summary>
         /// Higher than high, but not highest.
         /// </summary>
-        Higher  = 0x40000000,
+        Higher = -0x40000000,
         /// <summary>
         /// High.
         /// </summary>
-        High    = 0x20000000,
+        High = -0x20000000,
         /// <summary>
         /// Normal, the default level.
         /// </summary>
-        Normal  = 0,
+        Normal = 0,
         /// <summary>
         /// Low.
         /// </summary>
-        Low     = 0x20000000,
+        Low = 0x20000000,
         /// <summary>
         /// Lower than low, but not lowest.
         /// </summary>
-        Lower   = 0x40000000,
+        Lower = 0x40000000,
         /// <summary>
         /// The lowest priority. Things here happen last.
         /// </summary>
-        Lowest  = 0x60000000
+        Lowest = 0x60000000
     }
 }

--- a/src/Simple.Web/Routing/MatchData.cs
+++ b/src/Simple.Web/Routing/MatchData.cs
@@ -10,7 +10,7 @@ namespace Simple.Web.Routing
         private bool _set;
         private HandlerTypeInfo _single;
         private List<HandlerTypeInfo> _list;
-        private HandlerTypeInfo[] _prioritised; 
+        private HandlerTypeInfo[] _prioritised;
         private IDictionary<string, string> _variables;
 
         public IDictionary<string, string> Variables
@@ -68,7 +68,15 @@ namespace Simple.Web.Routing
             {
                 _variables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
-            _variables[key] = value;
+            if (_variables.ContainsKey(key))
+            {
+                // Append this value with a delimiter
+                _variables[key] += "\t" + value;
+            }
+            else
+            {
+                _variables.Add(key, value);
+            }
         }
 
         public Type ResolveByMediaTypes(string contentType, IList<string> acceptTypes)


### PR DESCRIPTION
Hi,

I would like to be able to have a handler that takes multiple values for the same query string key. (eg. /details?id=1&id=2&id=3).

I've added a test handler in the Sandbox project, and several tests to the HandlerBuilderFactory to cover the scenarios.

To get this to work, I made changes to the way the _variables_ dictionary is built up - so now if there is already a value with the same key, it appends to the existing value using a tab delimiter.  I'm not sure whether tab is the best delimiter to use in this scenario? - I followed a similar approach found in the Application::CombineQueryStringValues function.

The main bulk of the change was actually in the PropertySetterBuilder.cs file.  I extended the 'PropertyIsPrimitive' function to also check whether the property was an enumerable of primitive properties, and then in the 'CreateTrySimpleAssign' method, I added an extra condition to deal with an enumerable property.  In this scenario, it calls a different conversion method ('SafeConvertEnumerable') which creates a list and parses the (delimited) string to populate it.  

The Activator.CreateInstance call might be expensive here - what are your thoughts?  If there's a better way, I'd be glad to learn about it.

Finally, I spotted that in the Priority enum, Higher & High had the same value as Lower & Low - I assume that the Higher & High values should be negative?

If there is an alternative approach you would prefer for dealing with this scenario, let me know and I'll attempt it :)

Cheers,

Richard
