### PR TITLE
More testing, new failing test for JsonWithDeepLinks

### DIFF
--- a/src/Performance.MediaTypeHandlers/Performance.MediaTypeHandlers.csproj
+++ b/src/Performance.MediaTypeHandlers/Performance.MediaTypeHandlers.csproj
@@ -57,6 +57,7 @@
     </Compile>
     <Compile Include="CodeExecutionTimer.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="TestData.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Performance.MediaTypeHandlers/Program.cs
+++ b/src/Performance.MediaTypeHandlers/Program.cs
@@ -10,171 +10,70 @@ using Simple.Web.Xml.Tests;
 
 namespace Performance.MediaTypeHandlers
 {
-    internal class Program
+    internal static class Program
     {
+        private const int Iterations = 5000;
+
         private static void Main(string[] args)
         {
-            const int iterations = 5000;
             SimpleWeb.Configuration.Container = new XmlTestContainer();
 
-            Console.WriteLine("Creating Content");
-            IContent content = CreateContent();
+            Console.WriteLine("Performance testing of MediaTypeHandlers");
+            Console.WriteLine("\tS: Single Customer with 20 Orders");
+            Console.WriteLine("\tM: Five Customers with at least Five Orders");
+            Console.WriteLine();
+            Console.WriteLine("Testing over {0} iterations...", Iterations);
             Console.WriteLine();
 
-            Console.WriteLine("Testing ExplicitXml.Write<T> over {0} iterations...", iterations);
-            double explicitAverage = CodeExecutionTimer.Average(iterations, () => ExplicitXmlWrite(content));
-            Console.WriteLine("Average: {0}s", explicitAverage);
-            Console.WriteLine();
+            TestHandler("ExplicitXml    ", () => new ExplicitXmlMediaTypeHandler());
+            TestHandler("DataContractXml", () => new DataContractXmlMediaTypeHandler());
+            TestHandler("JsonNet        ", () => new JsonMediaTypeHandler());
+            TestHandler("HalJsonNet     ", () => new HalJsonMediaTypeHandler());
+            TestHandler("JsonNet W/Links", () => new JsonMediaTypeHandlerWithDeepLinks());
+            TestHandler("JsonFX         ", () => new Simple.Web.JsonFx.JsonMediaTypeHandler());
 
-            Console.WriteLine("Testing DataContractXml.Write<T> over {0} iterations...", iterations);
-            double dataContractAverage = CodeExecutionTimer.Average(iterations, () => DataContractXmlWrite(content));
-            Console.WriteLine("Average: {0}s", dataContractAverage);
             Console.WriteLine();
-
-            Console.WriteLine("Testing JsonNet.Write<T> over {0} iterations...", iterations);
-            double jsonNetAverage = CodeExecutionTimer.Average(iterations, () => JsonNetWrite(content));
-            Console.WriteLine("Average: {0}s", jsonNetAverage);
-            Console.WriteLine();
-
-            Console.WriteLine("Testing HalJsonNet.Write<T> over {0} iterations...", iterations);
-            double halJsonNetAverage = CodeExecutionTimer.Average(iterations, () => HalJsonNetWrite(content));
-            Console.WriteLine("Average: {0}s", halJsonNetAverage);
-            Console.WriteLine();
-
-            Console.WriteLine("Testing JsonNetWithDeepLinks.Write<T> over {0} iterations...", iterations);
-            double jsonNetDeepLinksAverage = CodeExecutionTimer.Average(iterations, () => JsonNetDeepLinksWrite(content));
-            Console.WriteLine("Average: {0}s", jsonNetDeepLinksAverage);
-            Console.WriteLine();
-
-            Console.WriteLine("Testing JsonFX.Write<T> over {0} iterations...", iterations);
-            double jsonFxAverage = CodeExecutionTimer.Average(iterations, () => JsonFxWrite(content));
-            Console.WriteLine("Average: {0}s", jsonFxAverage);
-            Console.WriteLine();
-
-            Console.WriteLine("Done");
+            Console.WriteLine("Done. Press 'Enter' to exit.");
             Console.ReadLine();
         }
 
-        private static IContent CreateContent()
+        private static void TestHandler(string name, Func<IMediaTypeHandler> ctor)
         {
-            var customers = new List<Customer>
+            Console.Write("{0}\t\tS: ", name);
+            double average = CodeExecutionTimer.Average(Iterations, () =>
                 {
-                    new Customer(1)
-                        {
-                            Orders = new List<Order>
-                                {
-                                    new Order(1, 100),
-                                    new Order(1, 101),
-                                    new Order(1, 102),
-                                    new Order(1, 103),
-                                    new Order(1, 104),
-                                }
-                        },
-                    new Customer(2)
-                        {
-                            Orders = new List<Order>
-                                {
-                                    new Order(2, 200),
-                                    new Order(2, 201),
-                                    new Order(2, 202),
-                                    new Order(2, 203),
-                                    new Order(2, 204),
-                                }
-                        },
-                    new Customer(3)
-                        {
-                            Orders = new List<Order>
-                                {
-                                    new Order(3, 300),
-                                    new Order(3, 301),
-                                    new Order(3, 302),
-                                    new Order(3, 303),
-                                    new Order(3, 304),
-                                }
-                        },
-                    new Customer(4)
-                        {
-                            Orders = new List<Order>
-                                {
-                                    new Order(4, 400),
-                                    new Order(4, 401),
-                                    new Order(4, 402),
-                                    new Order(4, 403),
-                                    new Order(4, 404),
-                                }
-                        },
-                    new Customer(5)
-                        {
-                            Orders = new List<Order>
-                                {
-                                    new Order(5, 500),
-                                    new Order(5, 501),
-                                    new Order(5, 502),
-                                    new Order(5, 503),
-                                    new Order(5, 504),
-                                    new Order(5, 505),
-                                    new Order(5, 506),
-                                    new Order(5, 507),
-                                    new Order(5, 508),
-                                    new Order(5, 509),
-                                    new Order(5, 510),
-                                    new Order(5, 511),
-                                    new Order(5, 512),
-                                    new Order(5, 513),
-                                    new Order(5, 514),
-                                    new Order(5, 515),
-                                    new Order(5, 516),
-                                    new Order(5, 517),
-                                    new Order(5, 518),
-                                    new Order(5, 519),
-                                }
-                        },
-                };
-            return new Content(new Uri("http://test.com/customers"), new CustomersHandler(), customers);
+                    IMediaTypeHandler handler = ctor();
+                    TestWriteSingle(handler);
+                });
+            Console.Write("{0:0.0000000000}s\tM: ", average);
+            average = CodeExecutionTimer.Average(Iterations, () =>
+                {
+                    IMediaTypeHandler handler = ctor();
+                    TestWriteMultiple(handler);
+                });
+            Console.WriteLine("{0:0.0000000000}s", average);
         }
 
-        private static void ExplicitXmlWrite(IContent content)
-        {
-            var handler = new ExplicitXmlMediaTypeHandler();
-            TestWrite(handler, content);
-        }
-
-        private static void DataContractXmlWrite(IContent content)
-        {
-            var handler = new DataContractXmlMediaTypeHandler();
-            TestWrite(handler, content);
-        }
-
-        private static void JsonNetWrite(IContent content)
-        {
-            var handler = new JsonMediaTypeHandler();
-            TestWrite(handler, content);
-        }
-
-        private static void HalJsonNetWrite(IContent content)
-        {
-            var handler = new HalJsonMediaTypeHandler();
-            TestWrite(handler, content);
-        }
-
-        private static void JsonNetDeepLinksWrite(IContent content)
-        {
-            var handler = new JsonMediaTypeHandlerWithDeepLinks();
-            TestWrite(handler, content);
-        }
-
-        private static void JsonFxWrite(IContent content)
-        {
-            var handler = new Simple.Web.JsonFx.JsonMediaTypeHandler();
-            TestWrite(handler, content);
-        }
-
-        private static void TestWrite(IMediaTypeHandler handler, IContent content)
+        private static void TestWriteSingle(IMediaTypeHandler handler)
         {
             string actual;
             using (var stream = new StringBuilderStream())
             {
-                handler.Write<Customer>(content, stream).Wait();
+                handler.Write<Customer>(TestData.SingleContent, stream).Wait();
+                actual = stream.StringValue;
+            }
+            if (actual == null)
+            {
+                throw new Exception("No Output!");
+            }
+        }
+
+        private static void TestWriteMultiple(IMediaTypeHandler handler)
+        {
+            string actual;
+            using (var stream = new StringBuilderStream())
+            {
+                handler.Write<IEnumerable<Customer>>(TestData.MultipleContent, stream).Wait();
                 actual = stream.StringValue;
             }
             if (actual == null)

--- a/src/Performance.MediaTypeHandlers/TestData.cs
+++ b/src/Performance.MediaTypeHandlers/TestData.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using Simple.Web.MediaTypeHandling;
+using Simple.Web.TestHelpers.Sample;
+
+namespace Performance.MediaTypeHandlers
+{
+    public static class TestData
+    {
+        public static readonly List<Customer> Customers = new List<Customer>
+            {
+                new Customer(1)
+                    {
+                        Orders = new List<Order>
+                            {
+                                new Order(1, 100),
+                                new Order(1, 101),
+                                new Order(1, 102),
+                                new Order(1, 103),
+                                new Order(1, 104),
+                                new Order(1, 101),
+                                new Order(1, 106),
+                                new Order(1, 107),
+                                new Order(1, 108),
+                                new Order(1, 109),
+                                new Order(1, 110),
+                                new Order(1, 111),
+                                new Order(1, 112),
+                                new Order(1, 113),
+                                new Order(1, 114),
+                                new Order(1, 115),
+                                new Order(1, 116),
+                                new Order(1, 117),
+                                new Order(1, 118),
+                                new Order(1, 119),
+                            }
+                    },
+                new Customer(2)
+                    {
+                        Orders = new List<Order>
+                            {
+                                new Order(2, 200),
+                                new Order(2, 201),
+                                new Order(2, 202),
+                                new Order(2, 203),
+                                new Order(2, 204),
+                            }
+                    },
+                new Customer(3)
+                    {
+                        Orders = new List<Order>
+                            {
+                                new Order(3, 300),
+                                new Order(3, 301),
+                                new Order(3, 302),
+                                new Order(3, 303),
+                                new Order(3, 304),
+                            }
+                    },
+                new Customer(4)
+                    {
+                        Orders = new List<Order>
+                            {
+                                new Order(4, 400),
+                                new Order(4, 401),
+                                new Order(4, 402),
+                                new Order(4, 403),
+                                new Order(4, 404),
+                            }
+                    },
+                new Customer(5)
+                    {
+                        Orders = new List<Order>
+                            {
+                                new Order(5, 500),
+                                new Order(5, 501),
+                                new Order(5, 502),
+                                new Order(5, 503),
+                                new Order(5, 504),
+                            }
+                    },
+            };
+
+        public static readonly IContent SingleContent = new Content(new Uri("http://test.com/customer/1"),
+                                                                    new CustomerHandler(),
+                                                                    Customers[0]);
+
+        public static readonly IContent MultipleContent = new Content(new Uri("http://test.com/customers"),
+                                                                      new CustomersHandler(),
+                                                                      Customers);
+    }
+}

--- a/src/Simple.Web.JsonFx.Tests/JsonFxContentTypeHandlerTests.cs
+++ b/src/Simple.Web.JsonFx.Tests/JsonFxContentTypeHandlerTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Simple.Web.JsonFx.Tests
+﻿using System.Collections.Generic;
+
+namespace Simple.Web.JsonFx.Tests
 {
     using System;
     using System.IO;
@@ -48,7 +50,7 @@
             string actual;
             using (var stream = new StringBuilderStream())
             {
-                target.Write<Customer>(content, stream).Wait();
+                target.Write<IEnumerable<Customer>>(content, stream).Wait();
                 actual = stream.StringValue;
             }
             Assert.NotNull(actual);

--- a/src/Simple.Web.JsonNet.Tests/HalJsonMediaTypeHandlerTests.cs
+++ b/src/Simple.Web.JsonNet.Tests/HalJsonMediaTypeHandlerTests.cs
@@ -80,7 +80,7 @@ namespace Simple.Web.JsonNet.Tests
             var target = new HalJsonMediaTypeHandler();
             using (var stream = new MemoryStream())
             {
-                target.Write<Person>(content, stream).Wait();
+                target.Write<IEnumerable<Person>>(content, stream).Wait();
                 stream.Position = 0;
                 string text = new StreamReader(stream).ReadToEnd();
                 actual = JObject.Parse(text);

--- a/src/Simple.Web.JsonNet.Tests/JsonMediaTypeHandlerTests.cs
+++ b/src/Simple.Web.JsonNet.Tests/JsonMediaTypeHandlerTests.cs
@@ -2,9 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using MediaTypeHandling;
-    using Newtonsoft.Json.Linq;
     using TestHelpers;
     using TestHelpers.Sample;
     using Xunit;
@@ -86,7 +84,7 @@
             string actual;
             using (var stream = new StringBuilderStream())
             {
-                target.Write<Customer>(content, stream).Wait();
+                target.Write<IEnumerable<Customer>>(content, stream).Wait();
                 actual = stream.StringValue;
             }
             Assert.NotNull(actual);

--- a/src/Simple.Web.JsonNet/LinkConverter.cs
+++ b/src/Simple.Web.JsonNet/LinkConverter.cs
@@ -53,6 +53,10 @@
 
         private static JsonConverter Build(Type type, Func<object, IEnumerable<object>> linkEnumerator, IContractResolver contractResolver)
         {
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof (IEnumerable<>))
+            {
+                return Build(type.GetGenericArguments().Single(), linkEnumerator, contractResolver);
+            }
             var enumerable = type.GetInterface(typeof (IEnumerable<>).FullName);
             if (enumerable != null)
             {

--- a/src/Simple.Web.Xml.Tests/ExplicitXmlContentTypeHandlerTests.cs
+++ b/src/Simple.Web.Xml.Tests/ExplicitXmlContentTypeHandlerTests.cs
@@ -30,9 +30,7 @@ namespace Simple.Web.Xml.Tests
             }
             Assert.NotNull(actual);
 
-            const string expected = "<Order>" +
-                                    "  <CustomerId>42</CustomerId>" +
-                                    "  <Id>54</Id>" +
+            const string expected = "<Order Id='54' CustomerId='42'>" +
                                     "  <link href='/order/54' rel='self' type='application/vnd.order+xml' />" +
                                     "</Order>";
 
@@ -53,8 +51,7 @@ namespace Simple.Web.Xml.Tests
             }
             Assert.NotNull(actual);
 
-            const string expected = "<Customer>" +
-                                    "  <Id>42</Id>" +
+            const string expected = "<Customer Id='42'>" +
                                     "  <link href='/customer/42/contacts' rel='customer.contacts' type='application/vnd.contact+xml' />" +
                                     "  <link href='/customer/42/orders' rel='customer.orders' type='application/vnd.list.order+xml' />" +
                                     "  <link href='/customer/42' rel='self' type='application/vnd.customer+xml' />" +
@@ -78,8 +75,7 @@ namespace Simple.Web.Xml.Tests
             Assert.NotNull(actual);
 
             const string expected = "<Customers>" +
-                                    "  <Customer>" +
-                                    "    <Id>42</Id>" +
+                                    "  <Customer Id='42'>" +
                                     "    <link href='/customer/42/contacts' rel='customer.contacts' type='application/vnd.contact+xml' />" +
                                     "    <link href='/customer/42/orders' rel='customer.orders' type='application/vnd.list.order+xml' xmlns='' />" +
                                     "    <link href='/customer/42' rel='self' type='application/vnd.customer+xml' xmlns='' />" +

--- a/src/Simple.Web.Xml.Tests/XmlTestConverters.cs
+++ b/src/Simple.Web.Xml.Tests/XmlTestConverters.cs
@@ -6,6 +6,8 @@ namespace Simple.Web.Xml.Tests
 {
     internal class OrderConverter : XmlConverter<Order>
     {
+        internal static readonly OrderConverter Instance = new OrderConverter();
+
         public override Order FromXml(XElement wireFormat)
         {
             throw new NotImplementedException();
@@ -14,8 +16,8 @@ namespace Simple.Web.Xml.Tests
         public override XElement ToXml(Order value)
         {
             return new XElement("Order",
-                                new XElement("CustomerId", value.CustomerId),
-                                new XElement("Id", value.Id));
+                                new XAttribute("Id", value.Id),
+                                new XAttribute("CustomerId", value.CustomerId));
         }
     }
 
@@ -28,8 +30,16 @@ namespace Simple.Web.Xml.Tests
 
         public override XElement ToXml(Customer value)
         {
-            return new XElement("Customer",
-                                new XElement("Id", value.Id));
+            var xml = new XElement("Customer",
+                                   new XAttribute("Id", value.Id));
+            if (value.Orders != null && value.Orders.Count > 0)
+            {
+                foreach (Order order in value.Orders)
+                {
+                    xml.Add(OrderConverter.Instance.ToXml(order));
+                }
+            }
+            return xml;
         }
     }
 }


### PR DESCRIPTION
Better performance test harness for `IMediaTypeHandlers`

Fix mediaTypeHandler tests to use `.Write<IEnumerable<X>>()` where we would expect `IOutput<IEnumerable<X>>`

`LinkConverter` now doesn't barf when passed an `IEnumerable<>` interface directly.

JsonWithDeepLinks, links in the entire hierarchy still do not work.

ExplicitTestConverters will write full graph now, on par with other converters
