### PR TITLE
Fixed issue with Owin delegate

### DIFF
--- a/src/Simple.Web.Tests/OwinSupport/OwinHelpersTests.cs
+++ b/src/Simple.Web.Tests/OwinSupport/OwinHelpersTests.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+
+namespace Simple.Web.Tests.OwinSupport
+{
+    using System;
+    using Owin;
+    using Web.OwinSupport;
+    using Xunit;
+
+    using AppFunc = System.Func<IDictionary<string, object>, System.Threading.Tasks.Task>;
+
+    public class OwinHelpersTests
+    {
+        [Fact]
+        public void UseSimpleWebUseCompatibleDelegate()
+        {
+            var mockAppBuilder = new MockAppBuilder();
+
+            mockAppBuilder.UseSimpleWeb();
+
+            Assert.IsAssignableFrom<Func<AppFunc, AppFunc>>(mockAppBuilder.AssignedMiddleWare);
+        }
+
+        private class MockAppBuilder : IAppBuilder
+        {
+            public IAppBuilder Use(object middleware, params object[] args)
+            {
+                AssignedMiddleWare = middleware;
+                return this;
+            }
+
+            public object AssignedMiddleWare { get; private set; }
+
+            public object Build(Type returnType)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IAppBuilder New()
+            {
+                throw new NotImplementedException();
+            }
+
+            public IDictionary<string, object> Properties { get; private set; }
+        }
+
+    }
+}

--- a/src/Simple.Web.Tests/Simple.Web.Tests.csproj
+++ b/src/Simple.Web.Tests/Simple.Web.Tests.csproj
@@ -33,6 +33,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -57,6 +61,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="MediaTypeHandling\MediaTypeHandlerExTests.cs" />
+    <Compile Include="OwinSupport\OwinHelpersTests.cs" />
     <Compile Include="PublicFolderTests.cs" />
     <Compile Include="UriFromTypeTests.cs" />
     <Compile Include="UriTemplateAttributeTests.cs" />

--- a/src/Simple.Web.Tests/packages.config
+++ b/src/Simple.Web.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Owin" version="1.0" targetFramework="net40" />
   <package id="xunit" version="1.9.1" targetFramework="net40" />
 </packages>

--- a/src/Simple.Web/OwinSupport/OwinHelpers.cs
+++ b/src/Simple.Web/OwinSupport/OwinHelpers.cs
@@ -1,15 +1,15 @@
 ﻿namespace Simple.Web.OwinSupport
 {
     using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Owin;
+
+    using AppFunc = System.Func<System.Collections.Generic.IDictionary<string, object>, System.Threading.Tasks.Task>;
 
     public static class OwinHelpers
     {
         public static void UseSimpleWeb(this IAppBuilder app)
         {
-            app.Use(new Func<IDictionary<string,object>, Func<IDictionary<string,object>, Task>, Task>(Application.Run));
+            app.Use(new Func<AppFunc, AppFunc>(nextAppFunc => (AppFunc) (context => Application.Run(context, nextAppFunc))));
         }
     }
 }

--- a/src/Simple.Web/OwinSupport/OwinStartupBase.cs
+++ b/src/Simple.Web/OwinSupport/OwinStartupBase.cs
@@ -21,7 +21,7 @@
 
         protected OwinStartupBase()
         {
-            this._builder = builder => builder.Use(new Func<IDictionary<string,object>, Func<IDictionary<string,object>, Task>, Task>(Application.Run));
+            this._builder = builder => builder.UseSimpleWeb();
         }
 
         protected OwinStartupBase(Action<IAppBuilder> builder)


### PR DESCRIPTION
- Changed OwinStartupBase to use OwinHelpers extension method

I couldn't get the samples for owin to work, so i tried to change UseSimpleWeb to be compatible with "Owin" signature.

I could not get rake full to run, something with:
error: Could not find file: C:\src\fromgit\Simple.Web\src\Simple.Web.Razor.Tests.ExternalDummyAssembly\bin\Release\xunit
.dll

So seems like it's trying to run tests in ExternalDummyAssembly and failing on that because that assembly doesn't have a reference to xunit. I'm not that keen on rake/ruby but guees it should not try to run tests in ExternalDummyAssembly.

Please advice
